### PR TITLE
fix: increase AWS S3 socket pool size to prevent socket warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.279.0",
+    "@aws-sdk/node-http-handler": "^3.279.0",
     "adform-upload-tool": "^1.0.4",
     "axios": "^1.3.4",
     "chalk": "^4.1.2",

--- a/src/target/mm-preview.js
+++ b/src/target/mm-preview.js
@@ -8,6 +8,7 @@ const path = require('path');
 const fs = require('fs');
 const globPromise = require('glob-promise');
 const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
 const cliProgress = require('cli-progress');
 
 const mime = require('mime-types');
@@ -65,6 +66,13 @@ const preview = {
         accessKeyId: data.accessKeyId,
         secretAccessKey: data.secretAccessKey,
       },
+      requestHandler: new NodeHttpHandler({
+        socketTimeout: 3000,
+        timeoutByRequestType: {
+          default: 3000
+        },
+        maxSockets: 200 // Increase from default 50
+      })
     });
 
     const allFiles = await globPromise(`${data.inputDir.replace(/\\/g, '/')}/**/*`);


### PR DESCRIPTION
## Changes
- Increased AWS S3 socket pool size from 50 to 200
- Added socket timeout configuration
- Added NodeHttpHandler configuration

## Issue
Fixes socket usage capacity warnings when uploading multiple files

## Testing
- Tested with large batch uploads
- Verified socket warnings are resolved